### PR TITLE
Error compile C/Cpp file with Spaces in Name (Win)

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,8 +137,8 @@
           "default": {
             "javascript": "node",
             "java": "cd $dir && javac $fileName && java $fileNameWithoutExt",
-            "c": "cd $dir && gcc $fileName -o $fileNameWithoutExt && $dir$fileNameWithoutExt",
-            "cpp": "cd $dir && g++ $fileName -o $fileNameWithoutExt && $dir$fileNameWithoutExt",
+            "c": "cd $dir && gcc '$fileName' -o '$fileNameWithoutExt' && ./'$fileNameWithoutExt'",
+            "cpp": "cd $dir && g++ '$fileName' -o '$fileNameWithoutExt' && ./'$fileNameWithoutExt'",
             "objective-c": "cd $dir && gcc -framework Cocoa $fileName -o $fileNameWithoutExt && $dir$fileNameWithoutExt",
             "php": "php",
             "python": "python -u",


### PR DESCRIPTION
In Windows, compiling C/Cpp Source files with Spaces in File Name like "2 1.cpp" throws an Error like following :

" g++.exe: error: 2: No such file or directory
g++.exe: error: 1.CPP: No such file or directory
g++.exe: error: 1: No such file or directory
g++.exe: fatal error: no input files "

This is because the terminal takes Each word as an argument, so when we give file name within quotes, whole file name is taken as an argument.

But using '$dir' again throws an error like following :

"cd "d:\Notes\3\Progrommes\PPL\" ; if ($?) { g++ '2 1.CPP' -o '2 1' } ; if ($?) { .\2 1 }
.\2: The term '.\2' is not recognized as a name of a cmdlet, function, script file, or executable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
s\3\Progrommes\PPL\"'2 1' }ParserError:
Line |
   1 |  …  '2 1.CPP' -o '2 1' } ; if ($?) { "d:\Notes\3\Progrommes\PPL\"'2 1' }
     |                                                                  ~~~~~
     | Unexpected token ''2 1'' in expression or statement."

As we are already in pwd we can use ". /" to open files in directory.

I'm working with C & Cpp, don't know about "objective-C", please review that language also.